### PR TITLE
Fix path grid edge case in DelayDays

### DIFF
--- a/Source/DelayDays.cs
+++ b/Source/DelayDays.cs
@@ -28,6 +28,11 @@ namespace Safely_Hidden_Away
 			int foundTile;
 			if (!TryFindClosestTile(tile, t => !Find.World.Impassable(t), validator, out foundTile))
 				TryFindClosestTile(tile, t => !Find.World.Impassable(t) || waterValidator(t), waterValidator, out foundTile);
+
+			if (foundTile < 0) // this can happen if the tile is completely encased by impassable mountains
+			{
+				return 10; // fallback to a fixed delay of 10 days
+			}
 			
 			//spammed in settings
 			//Log.Message($"Closest tile to {map} is {foundTile}:{Find.World.grid[foundTile]}");


### PR DESCRIPTION
Currently the tile search code throws an exception if the origin tile is completely encased by impassable mountains.

Example (vanilla)
seed: eggplant
tile: 59313

![RimWorldWin64_FGrFIWIiTF](https://github.com/alextd/RimWorld-SafelyHiddenAway/assets/36201707/5eefc58f-9e5c-4e48-83a1-97926a486035)

Exception:
```
System.ArgumentOutOfRangeException: Index was out of range. Must be non-negative and less than the size of the collection.
Parameter name: index
  at System.ThrowHelper.ThrowArgumentOutOfRangeException (System.ExceptionArgument argument, System.ExceptionResource resource) [0x00029] in <eae584ce26bc40229c1b1aa476bfa589>:0 
  at System.ThrowHelper.ThrowArgumentOutOfRangeException () [0x00000] in <eae584ce26bc40229c1b1aa476bfa589>:0 
  at RimWorld.Planet.PackedListOfLists.GetList[T] (System.Collections.Generic.List`1[T] offsets, System.Collections.Generic.List`1[T] values, System.Int32 listIndex, System.Collections.Generic.List`1[T] outList) [0x0003d] in <95de19971c5d40878d8742747904cdcd>:0 
  at RimWorld.Planet.WorldGrid.GetTileNeighbors (System.Int32 tileID, System.Collections.Generic.List`1[T] outNeighbors) [0x00000] in <95de19971c5d40878d8742747904cdcd>:0 
  at Safely_Hidden_Away.DelayDays.DaysTo (Verse.Map map, System.Func`2[T,TResult] factionValidator) [0x000e8] in <7f11b32814d8480bb20b1a1eb089d2b1>:0 
  at Safely_Hidden_Away.DelayDays.DelayRaidDays (Verse.Map map) [0x00000] in <7f11b32814d8480bb20b1a1eb089d2b1>:0 
  at Safely_Hidden_Away.CycleDampener.Postfix (RimWorld.StoryState __instance, RimWorld.FiringIncident fi, RimWorld.IIncidentTarget ___target, System.Int32& ___lastThreatBigTick) [0x00064] in <7f11b32814d8480bb20b1a1eb089d2b1>:0 
  at (wrapper dynamic-method) RimWorld.StoryState.RimWorld.StoryState.Notify_IncidentFired_Patch1(RimWorld.StoryState,RimWorld.FiringIncident)
  at (wrapper dynamic-method) RimWorld.Storyteller.RimWorld.Storyteller.TryFire_Patch1(RimWorld.Storyteller,RimWorld.FiringIncident)
  at (wrapper dynamic-method) RimWorld.Storyteller.RimWorld.Storyteller.StorytellerTick_Patch1(RimWorld.Storyteller)
  at (wrapper dynamic-method) Verse.TickManager.Verse.TickManager.DoSingleTick_Patch4(Verse.TickManager) 
```

This PR adds an additional check to avoid this and instead return a fixed delay in this situation.